### PR TITLE
[#7] feat :: 별명 자동 생성 api 추가

### DIFF
--- a/src/routes/authRoute.ts
+++ b/src/routes/authRoute.ts
@@ -10,6 +10,7 @@ import {
   // 별명 관련 함수들
   updateUsername,
   checkUsername,
+  generateUsernameAPI,
   // 이메일 인증 관련 함수들
   resetPasswordRequest,
   verifyResetPassword,
@@ -35,6 +36,9 @@ router.post("/resend-code", resendVerificationCode);
 
 // 별명 중복 체크 (회원가입 시에도 필요하므로 인증 불필요)
 router.post("/check-username", checkUsername);
+
+// 별명 자동 생성 (이메일기반 자동 생성, 중복시 숫자 추가)
+router.get('/generate-username', generateUsernameAPI);
 
 // === 인증이 필요한 라우트들 ===
 


### PR DESCRIPTION
예시 1: 기본 이메일 기반 생성
email: "john.doe@gmail.com"
→ 생성결과: "johndoe" (특수문자 제거)

예시 2: 중복이 있는 경우
email: "user@example.com" (이미 "user"가 존재)
→ 생성결과: "user1" → "user2" → "user3" ...

예시 3: 한글 이름
email: "김철수@naver.com"
→ 생성결과: "김철수"

예시 4: 너무 긴 경우
email: "verylongemailaddress@domain.com"
→ 생성결과: "verylongemailadd" (15자로 제한)

예시 5: 너무 짧은 경우
email: "a@b.com"
→ 생성결과: "user" (최소 길이 보장)

예시 6: 기본값 제공
email: "test@example.com", base: "coolname"
→ 생성결과: "coolname" (사용 가능하면)
→ 또는 "coolname1" (중복시)